### PR TITLE
Use PSR-4 instead of PSR-0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,15 @@ New Relic Insights Library
 Use this library to easily post custom events to New Relic Insights.
 
 ```php
+<?php
+
+use EasyTaxi\NewRelic\Insights;
+
 $client = new Client([
     #You need to change it to your account number
     'base_uri' => 'https://insights-collector.newrelic.com/v1/accounts/99999/'
 ]);
-$this->newRelicInsights = new NewRelic\Insights($client, 'YOUR_KEY_HERE');
+$this->newRelicInsights = new EasyTaxi\NewRelic\Insights($client, 'YOUR_KEY_HERE');
 
 $events = new Insights\EventCollection();
 

--- a/composer.json
+++ b/composer.json
@@ -2,8 +2,8 @@
     "name": "easytaxibr/newrelic-insights",
     "description": "A simple wrapper for NewRelic Insights API",
     "autoload": {
-        "psr-0" : {
-            "NewRelic" : "src"
+        "psr-4" : {
+            "EasyTaxi\\NewRelic\\" : "src"
         }
     },
     "require": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,15 +18,15 @@
 
     <testsuites>
         <testsuite name="NewRelic Insights Test ">
-            <directory>src/NewRelic/Test</directory>
+            <directory>src/Test</directory>
         </testsuite>
     </testsuites>
 
     <filter>
         <whitelist>
-            <directory>src/NewRelic/Test</directory>
+            <directory>src/Test</directory>
             <exclude>
-                <directory>src/NewRelic/Test</directory>
+                <directory>src/Test</directory>
             </exclude>
         </whitelist>
     </filter>

--- a/src/Entity/Insights/Event.php
+++ b/src/Entity/Insights/Event.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace NewRelic\Entity\Insights;
+namespace EasyTaxi\NewRelic\Entity\Insights;
 
 use Respect\Validation\Validator;
 

--- a/src/Entity/Insights/EventCollection.php
+++ b/src/Entity/Insights/EventCollection.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace NewRelic\Entity\Insights;
+namespace EasyTaxi\NewRelic\Entity\Insights;
 
 class EventCollection extends \ArrayObject implements \JsonSerializable
 {

--- a/src/Insights.php
+++ b/src/Insights.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace NewRelic;
+namespace EasyTaxi\NewRelic;
 
 use GuzzleHttp\Client;
-use NewRelic\Entity\Insights\EventCollection;
+use EasyTaxi\NewRelic\Entity\Insights\EventCollection;
 use Respect\Validation\Validator;
 
 class Insights

--- a/src/Test/InsightsTest.php
+++ b/src/Test/InsightsTest.php
@@ -9,7 +9,9 @@ use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Promise;
 use GuzzleHttp\Middleware;
-use NewRelic\Entity\Insights;
+use EasyTaxi\NewRelic\Insights;
+use EasyTaxi\NewRelic\Entity\Insights\EventCollection;
+use EasyTaxi\NewRelic\Entity\Insights\Event;
 
 class InsightsTest extends \PHPUnit_Framework_TestCase
 {
@@ -28,12 +30,12 @@ class InsightsTest extends \PHPUnit_Framework_TestCase
             'handler' => $handler,
             'base_uri' => 'http://WhoCares'
         ]);
-        $this->newRelicInsights = new NewRelic\Insights($client, 'Mum-Ha');
+        $this->newRelicInsights = new Insights($client, 'Mum-Ha');
     }
 
     public function testCanSendAsyncRequest()
     {
-        $promise = $this->newRelicInsights->sendEvent(new Insights\EventCollection());
+        $promise = $this->newRelicInsights->sendEvent(new EventCollection());
 
         $response = $promise->wait();
         $this->assertEquals(200, $response->getStatusCode());
@@ -41,11 +43,11 @@ class InsightsTest extends \PHPUnit_Framework_TestCase
 
     public function testFulfillMessageInterface()
     {
-        $event = new Insights\Event();
+        $event = new Event();
         $event->eventType = "Purchase";
         $event->account = 3;
         $event->amount = 259.54;
-        $events = new Insights\EventCollection();
+        $events = new EventCollection();
         $events->add($event);
 
         $promise = $this->newRelicInsights->sendEvent($events);
@@ -73,9 +75,9 @@ class InsightsTest extends \PHPUnit_Framework_TestCase
      */
     public function testEventType($type)
     {
-        $event = new Insights\Event();
+        $event = new Event();
         $event->eventType = $type;
-        $events = new Insights\EventCollection();
+        $events = new EventCollection();
         $events->add($event);
 
         $this->newRelicInsights->sendEvent($events);


### PR DESCRIPTION
Following the PHP Framework Interop Group and their patterns, [PSR-0 has been marked as deprecated](http://www.php-fig.org/psr/psr-0/) since 2014 in favor to [PSR-4](http://www.php-fig.org/psr/psr-4/).

